### PR TITLE
Use singular "day" when there's only one day left.

### DIFF
--- a/Form1.frm
+++ b/Form1.frm
@@ -91,6 +91,8 @@ Public Sub UpdateCaption()
     dateDifference = DateDiff("d", Now, vacationDate)
     If dateDifference < 0 Then
         CountdownLabel.Caption = Abs(dateDifference) & " days since Disney"
+    ElseIf dateDifference = 1 Then
+        CountdownLabel.Caption = Abs(dateDifference) & " days since Disney"
     Else
         CountdownLabel.Caption = dateDifference & " days until Disney!"
     End If


### PR DESCRIPTION
This was an easy add, there was no reason to keep this out from the original >:L